### PR TITLE
chore: update golangci-lint config for v1.64.5

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,4 +33,4 @@ linters:
   - canonicalheader   # The headers in http.Request are canonical by default
   - promlinter
   - containedctx
-  - exportloopref     # Disable because they are deprecated and throw warning in logs
+  - tenv              # Disable because it is deprecated and warnings are thrown in logs


### PR DESCRIPTION
- remove `exportloopref` from disabled linters because it is removed from golangci-lint
- add `tenv` to disabled linters because it is deprecated and throw warning in logs