### PR TITLE
chore: remove disabled linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,4 @@ linters:
   - varnamelen        # We want to be able to use short variable names
   - ireturn           # We want to be able to return interfaces
   - canonicalheader   # The headers in http.Request are canonical by default
-  - promlinter
-  - containedctx
   - tenv              # Disable because it is deprecated and warnings are thrown in logs


### PR DESCRIPTION
We don't have reasons anymore to disable those two linters: `promlinter` and `containedctx`.